### PR TITLE
Add basic issue tracking

### DIFF
--- a/DtiApplicationsIssuesTracker.Server/Controllers/IssueTrackerController.cs
+++ b/DtiApplicationsIssuesTracker.Server/Controllers/IssueTrackerController.cs
@@ -1,0 +1,68 @@
+using DtiApplicationsIssuesTracker.Server.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DtiApplicationsIssuesTracker.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class IssueTrackerController : ControllerBase
+    {
+        [HttpGet("repositories")]
+        public IActionResult GetRepositories()
+        {
+            return Ok(DataStore.Repositories.Values.OrderBy(r => r.Id));
+        }
+
+        [HttpPost("repositories")]
+        public IActionResult AddRepository([FromBody] Repository repo)
+        {
+            if (string.IsNullOrWhiteSpace(repo.Name)) return BadRequest();
+            var added = DataStore.AddRepository(repo.Name);
+            return Ok(added);
+        }
+
+        [HttpGet("categories")]
+        public IActionResult GetCategories()
+        {
+            return Ok(DataStore.Categories.Values.OrderBy(c => c.Id));
+        }
+
+        [HttpPost("categories")]
+        public IActionResult AddCategory([FromBody] Category category)
+        {
+            if (string.IsNullOrWhiteSpace(category.Name)) return BadRequest();
+            var added = DataStore.AddCategory(category.Name);
+            return Ok(added);
+        }
+
+        [HttpGet("datasources")]
+        public IActionResult GetDataSources()
+        {
+            return Ok(DataStore.DataSources.Values.OrderBy(d => d.Id));
+        }
+
+        [HttpPost("datasources")]
+        public IActionResult AddDataSource([FromBody] DataSource dataSource)
+        {
+            if (string.IsNullOrWhiteSpace(dataSource.Name)) return BadRequest();
+            var added = DataStore.AddDataSource(dataSource.Name);
+            return Ok(added);
+        }
+
+        [HttpGet("issues")]
+        public IActionResult GetIssues()
+        {
+            return Ok(DataStore.Issues.Values.OrderBy(i => i.Id));
+        }
+
+        [HttpPost("issues")]
+        public IActionResult AddIssue([FromBody] Issue issue)
+        {
+            if (!DataStore.Repositories.ContainsKey(issue.RepositoryId)) return BadRequest("Invalid repository");
+            if (!DataStore.Categories.ContainsKey(issue.CategoryId)) return BadRequest("Invalid category");
+            if (issue.DataSourceId.HasValue && !DataStore.DataSources.ContainsKey(issue.DataSourceId.Value)) return BadRequest("Invalid data source");
+            var added = DataStore.AddIssue(issue);
+            return Ok(added);
+        }
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/Category.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/Category.cs
@@ -1,0 +1,8 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public class Category
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/DataSource.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/DataSource.cs
@@ -1,0 +1,8 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public class DataSource
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/DataStore.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/DataStore.cs
@@ -1,0 +1,58 @@
+using System.Collections.Concurrent;
+
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public static class DataStore
+    {
+        public static ConcurrentDictionary<int, Repository> Repositories { get; } = new();
+        public static ConcurrentDictionary<int, Category> Categories { get; } = new();
+        public static ConcurrentDictionary<int, DataSource> DataSources { get; } = new();
+        public static ConcurrentDictionary<int, Issue> Issues { get; } = new();
+
+        private static int _repoId;
+        private static int _catId;
+        private static int _dsId;
+        private static int _issueId;
+
+        static DataStore()
+        {
+            // Seed with a couple of categories
+            var dataCategory = AddCategory("Data");
+            AddCategory("Bug");
+
+            // Add sample repository
+            AddRepository("SampleRepo");
+
+            // Add sample data source
+            AddDataSource("DefaultDB");
+        }
+
+        public static Repository AddRepository(string name)
+        {
+            var repo = new Repository { Id = ++_repoId, Name = name };
+            Repositories[repo.Id] = repo;
+            return repo;
+        }
+
+        public static Category AddCategory(string name)
+        {
+            var cat = new Category { Id = ++_catId, Name = name };
+            Categories[cat.Id] = cat;
+            return cat;
+        }
+
+        public static DataSource AddDataSource(string name)
+        {
+            var ds = new DataSource { Id = ++_dsId, Name = name };
+            DataSources[ds.Id] = ds;
+            return ds;
+        }
+
+        public static Issue AddIssue(Issue issue)
+        {
+            issue.Id = ++_issueId;
+            Issues[issue.Id] = issue;
+            return issue;
+        }
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/Issue.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/Issue.cs
@@ -1,0 +1,13 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public class Issue
+    {
+        public int Id { get; set; }
+        public int RepositoryId { get; set; }
+        public int CategoryId { get; set; }
+        public int? DataSourceId { get; set; }
+        public IssueStatus Status { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public string? Resolution { get; set; }
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/IssueStatus.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/IssueStatus.cs
@@ -1,0 +1,8 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public enum IssueStatus
+    {
+        Open = 0,
+        Resolved = 1
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/Repository.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/Repository.cs
@@ -1,0 +1,8 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public class Repository
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Program.cs
+++ b/DtiApplicationsIssuesTracker.Server/Program.cs
@@ -3,6 +3,13 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 
 builder.Services.AddControllers();
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -20,6 +27,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors();
 
 app.UseAuthorization();
 

--- a/dtiapplicationsissuestracker.client/src/App.tsx
+++ b/dtiapplicationsissuestracker.client/src/App.tsx
@@ -1,58 +1,191 @@
-import { useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import './App.css';
 
-interface Forecast {
-    date: string;
-    temperatureC: number;
-    temperatureF: number;
-    summary: string;
+interface Repository { id: number; name: string; }
+interface Category { id: number; name: string; }
+interface DataSource { id: number; name: string; }
+
+interface Issue {
+    id: number;
+    repositoryId: number;
+    categoryId: number;
+    dataSourceId?: number;
+    status: number;
+    description: string;
+    resolution?: string;
 }
 
+const statusOptions = [
+    { value: 0, label: 'Open' },
+    { value: 1, label: 'Resolved' }
+];
+
 function App() {
-    const [forecasts, setForecasts] = useState<Forecast[]>();
+    const [repositories, setRepositories] = useState<Repository[]>([]);
+    const [categories, setCategories] = useState<Category[]>([]);
+    const [dataSources, setDataSources] = useState<DataSource[]>([]);
+    const [issues, setIssues] = useState<Issue[]>([]);
+
+    const [repositoryId, setRepositoryId] = useState(0);
+    const [newRepo, setNewRepo] = useState('');
+    const [categoryId, setCategoryId] = useState(0);
+    const [newCategory, setNewCategory] = useState('');
+    const [dataSourceId, setDataSourceId] = useState<number | undefined>(undefined);
+    const [newDataSource, setNewDataSource] = useState('');
+    const [status, setStatus] = useState(0);
+    const [description, setDescription] = useState('');
+    const [resolution, setResolution] = useState('');
 
     useEffect(() => {
-        populateWeatherData();
+        loadAll();
     }, []);
 
-    const contents = forecasts === undefined
-        ? <p><em>Loading... Please refresh once the ASP.NET backend has started. See <a href="https://aka.ms/jspsintegrationreact">https://aka.ms/jspsintegrationreact</a> for more details.</em></p>
-        : <table className="table table-striped" aria-labelledby="tableLabel">
-            <thead>
-                <tr>
-                    <th>Date</th>
-                    <th>Temp. (C)</th>
-                    <th>Temp. (F)</th>
-                    <th>Summary</th>
-                </tr>
-            </thead>
-            <tbody>
-                {forecasts.map(forecast =>
-                    <tr key={forecast.date}>
-                        <td>{forecast.date}</td>
-                        <td>{forecast.temperatureC}</td>
-                        <td>{forecast.temperatureF}</td>
-                        <td>{forecast.summary}</td>
-                    </tr>
-                )}
-            </tbody>
-        </table>;
+    async function loadAll() {
+        const [repos, cats, dss, iss] = await Promise.all([
+            fetch('/api/issuetracker/repositories').then(r => r.json()),
+            fetch('/api/issuetracker/categories').then(r => r.json()),
+            fetch('/api/issuetracker/datasources').then(r => r.json()),
+            fetch('/api/issuetracker/issues').then(r => r.json()),
+        ]);
+        setRepositories(repos);
+        setCategories(cats);
+        setDataSources(dss);
+        setIssues(iss);
+    }
 
-    return (
-        <div>
-            <h1 id="tableLabel">Weather forecast</h1>
-            <p>This component demonstrates fetching data from the server.</p>
-            {contents}
-        </div>
-    );
+    async function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        let repoId = repositoryId;
+        if (!repoId && newRepo) {
+            const r = await fetch('/api/issuetracker/repositories', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: newRepo })
+            });
+            const repo = await r.json();
+            repoId = repo.id;
+            setRepositories([...repositories, repo]);
+            setNewRepo('');
+        }
+        let catId = categoryId;
+        if (!catId && newCategory) {
+            const r = await fetch('/api/issuetracker/categories', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: newCategory })
+            });
+            const cat = await r.json();
+            catId = cat.id;
+            setCategories([...categories, cat]);
+            setNewCategory('');
+        }
+        let dsId = dataSourceId;
+        if (categories.find(c => c.id === catId)?.name === 'Data') {
+            if (!dsId && newDataSource) {
+                const r = await fetch('/api/issuetracker/datasources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name: newDataSource })
+                });
+                const ds = await r.json();
+                dsId = ds.id;
+                setDataSources([...dataSources, ds]);
+                setNewDataSource('');
+            }
+        } else {
+            dsId = undefined;
+        }
 
-    async function populateWeatherData() {
-        const response = await fetch('weatherforecast');
-        if (response.ok) {
-            const data = await response.json();
-            setForecasts(data);
+        const issueBody = {
+            repositoryId: repoId,
+            categoryId: catId,
+            dataSourceId: dsId,
+            status,
+            description,
+            resolution: resolution || undefined
+        };
+
+        const res = await fetch('/api/issuetracker/issues', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(issueBody)
+        });
+        if (res.ok) {
+            const issue = await res.json();
+            setIssues([...issues, issue]);
+            setDescription('');
+            setResolution('');
+            setRepositoryId(0);
+            setCategoryId(0);
+            setDataSourceId(undefined);
         }
     }
+
+    const selectedCategory = categories.find(c => c.id === categoryId)?.name;
+    const showDataSource = selectedCategory === 'Data';
+
+    return (
+        <div className="container">
+            <h1>Issue Tracker</h1>
+            <form onSubmit={handleSubmit}>
+                <div>
+                    <label>Repository: </label>
+                    <select value={repositoryId} onChange={e => setRepositoryId(parseInt(e.target.value))}>
+                        <option value={0}>--Add New--</option>
+                        {repositories.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+                    </select>
+                    {repositoryId === 0 && (
+                        <input value={newRepo} onChange={e => setNewRepo(e.target.value)} placeholder="New repository" />
+                    )}
+                </div>
+                <div>
+                    <label>Category: </label>
+                    <select value={categoryId} onChange={e => setCategoryId(parseInt(e.target.value))}>
+                        <option value={0}>--Add New--</option>
+                        {categories.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                    </select>
+                    {categoryId === 0 && (
+                        <input value={newCategory} onChange={e => setNewCategory(e.target.value)} placeholder="New category" />
+                    )}
+                </div>
+                {showDataSource && (
+                    <div>
+                        <label>Data Source: </label>
+                        <select value={dataSourceId ?? 0} onChange={e => setDataSourceId(parseInt(e.target.value))}>
+                            <option value={0}>--Add New--</option>
+                            {dataSources.map(d => <option key={d.id} value={d.id}>{d.name}</option>)}
+                        </select>
+                        {(dataSourceId === undefined || dataSourceId === 0) && (
+                            <input value={newDataSource} onChange={e => setNewDataSource(e.target.value)} placeholder="New data source" />
+                        )}
+                    </div>
+                )}
+                <div>
+                    <label>Status: </label>
+                    <select value={status} onChange={e => setStatus(parseInt(e.target.value))}>
+                        {statusOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label>Description: </label>
+                    <textarea value={description} onChange={e => setDescription(e.target.value)} />
+                </div>
+                <div>
+                    <label>Resolution: </label>
+                    <textarea value={resolution} onChange={e => setResolution(e.target.value)} />
+                </div>
+                <button type="submit">Add Issue</button>
+            </form>
+            <h2>Existing Issues</h2>
+            <ul>
+                {issues.map(i => (
+                    <li key={i.id}>
+                        #{i.id} {repositories.find(r => r.id === i.repositoryId)?.name} - {categories.find(c => c.id === i.categoryId)?.name} - {statusOptions.find(s => s.value === i.status)?.label}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
 }
 
 export default App;


### PR DESCRIPTION
## Summary
- add controllers and models for tracking issues
- expose endpoints for repos, categories, data sources, and issues
- wire up in-memory datastore with some seed data
- replace the React sample with a simple issue tracker UI
- enable CORS so React client can call the API

## Testing
- `npm run build` *(fails: Cannot find type definition file)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6883aa0b336c832f860a16ebf3be7fd8