### PR TITLE
Add EF Core and SQL Server setup

### DIFF
--- a/DtiApplicationsIssuesTracker.Server/Controllers/IssueTrackerController.cs
+++ b/DtiApplicationsIssuesTracker.Server/Controllers/IssueTrackerController.cs
@@ -1,0 +1,121 @@
+using DtiApplicationsIssuesTracker.Server.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace DtiApplicationsIssuesTracker.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class IssueTrackerController : ControllerBase
+    {
+        private readonly IssueTrackingContext _context;
+
+        public IssueTrackerController(IssueTrackingContext context)
+        {
+            _context = context;
+        }
+        [HttpGet("repositories")]
+        public async Task<IActionResult> GetRepositories()
+        {
+            var repos = await _context.Repositories.OrderBy(r => r.Id).ToListAsync();
+            return Ok(repos);
+        }
+
+        [HttpPost("repositories")]
+        public async Task<IActionResult> AddRepository([FromBody] Repository repo)
+        {
+            if (string.IsNullOrWhiteSpace(repo.Name)) return BadRequest();
+            _context.Repositories.Add(repo);
+            await _context.SaveChangesAsync();
+            return Ok(repo);
+        }
+
+        [HttpGet("categories")]
+        public async Task<IActionResult> GetCategories()
+        {
+            var cats = await _context.Categories.OrderBy(c => c.Id).ToListAsync();
+            return Ok(cats);
+        }
+
+        [HttpPost("categories")]
+        public async Task<IActionResult> AddCategory([FromBody] Category category)
+        {
+            if (string.IsNullOrWhiteSpace(category.Name)) return BadRequest();
+            _context.Categories.Add(category);
+            await _context.SaveChangesAsync();
+            return Ok(category);
+        }
+
+        [HttpGet("datasources")]
+        public async Task<IActionResult> GetDataSources()
+        {
+            var dss = await _context.DataSources.OrderBy(d => d.Id).ToListAsync();
+            return Ok(dss);
+        }
+
+        [HttpPost("datasources")]
+        public async Task<IActionResult> AddDataSource([FromBody] DataSource dataSource)
+        {
+            if (string.IsNullOrWhiteSpace(dataSource.Name)) return BadRequest();
+            _context.DataSources.Add(dataSource);
+            await _context.SaveChangesAsync();
+            return Ok(dataSource);
+        }
+
+        [HttpGet("issues")]
+        public async Task<IActionResult> GetIssues()
+        {
+            var issues = await _context.Issues.OrderBy(i => i.Id).ToListAsync();
+            return Ok(issues);
+        }
+
+        [HttpPost("issues")]
+        public async Task<IActionResult> AddIssue([FromBody] Issue issue)
+        {
+            if (!await _context.Repositories.AnyAsync(r => r.Id == issue.RepositoryId)) return BadRequest("Invalid repository");
+            if (!await _context.Categories.AnyAsync(c => c.Id == issue.CategoryId)) return BadRequest("Invalid category");
+            if (issue.DataSourceId.HasValue && !await _context.DataSources.AnyAsync(d => d.Id == issue.DataSourceId.Value)) return BadRequest("Invalid data source");
+            _context.Issues.Add(issue);
+            await _context.SaveChangesAsync();
+            return Ok(issue);
+        }
+
+        [HttpGet("issues/{id}")]
+        public async Task<IActionResult> GetIssue(int id)
+        {
+            var issue = await _context.Issues.FindAsync(id);
+            if (issue == null) return NotFound();
+            return Ok(issue);
+        }
+
+        [HttpPut("issues/{id}")]
+        public async Task<IActionResult> UpdateIssue(int id, [FromBody] Issue updated)
+        {
+            var issue = await _context.Issues.FindAsync(id);
+            if (issue == null) return NotFound();
+            if (!await _context.Repositories.AnyAsync(r => r.Id == updated.RepositoryId)) return BadRequest("Invalid repository");
+            if (!await _context.Categories.AnyAsync(c => c.Id == updated.CategoryId)) return BadRequest("Invalid category");
+            if (updated.DataSourceId.HasValue && !await _context.DataSources.AnyAsync(d => d.Id == updated.DataSourceId.Value)) return BadRequest("Invalid data source");
+
+            issue.RepositoryId = updated.RepositoryId;
+            issue.CategoryId = updated.CategoryId;
+            issue.DataSourceId = updated.DataSourceId;
+            issue.Status = updated.Status;
+            issue.Description = updated.Description;
+            issue.Resolution = updated.Resolution;
+
+            await _context.SaveChangesAsync();
+            return Ok(issue);
+        }
+
+        [HttpDelete("issues/{id}")]
+        public async Task<IActionResult> DeleteIssue(int id)
+        {
+            var issue = await _context.Issues.FindAsync(id);
+            if (issue == null) return NotFound();
+            _context.Issues.Remove(issue);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/DtiApplicationsIssuesTracker.Server.csproj
+++ b/DtiApplicationsIssuesTracker.Server/DtiApplicationsIssuesTracker.Server.csproj
@@ -14,6 +14,8 @@
       <Version>8.*-*</Version>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DtiApplicationsIssuesTracker.Server/Models/Category.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/Category.cs
@@ -1,0 +1,8 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public class Category
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/DataSource.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/DataSource.cs
@@ -1,0 +1,8 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public class DataSource
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/Issue.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/Issue.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    [Table("ApplicationIssuesTracking")]
+    public class Issue
+    {
+        public int Id { get; set; }
+        public int RepositoryId { get; set; }
+        public int CategoryId { get; set; }
+        public int? DataSourceId { get; set; }
+        public IssueStatus Status { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public string? Resolution { get; set; }
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/IssueStatus.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/IssueStatus.cs
@@ -1,0 +1,8 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public enum IssueStatus
+    {
+        Open = 0,
+        Resolved = 1
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/IssueTrackingContext.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/IssueTrackingContext.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public class IssueTrackingContext : DbContext
+    {
+        public IssueTrackingContext(DbContextOptions<IssueTrackingContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Repository> Repositories { get; set; }
+        public DbSet<Category> Categories { get; set; }
+        public DbSet<DataSource> DataSources { get; set; }
+        public DbSet<Issue> Issues { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<Issue>().ToTable("ApplicationIssuesTracking");
+        }
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Models/Repository.cs
+++ b/DtiApplicationsIssuesTracker.Server/Models/Repository.cs
@@ -1,0 +1,8 @@
+namespace DtiApplicationsIssuesTracker.Server.Models
+{
+    public class Repository
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/DtiApplicationsIssuesTracker.Server/Program.cs
+++ b/DtiApplicationsIssuesTracker.Server/Program.cs
@@ -1,13 +1,31 @@
+using DtiApplicationsIssuesTracker.Server.Models;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
+builder.Services.AddDbContext<IssueTrackingContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<IssueTrackingContext>();
+    db.Database.EnsureCreated();
+}
 
 app.UseDefaultFiles();
 app.UseStaticFiles();
@@ -20,6 +38,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors();
 
 app.UseAuthorization();
 

--- a/DtiApplicationsIssuesTracker.Server/appsettings.Development.json
+++ b/DtiApplicationsIssuesTracker.Server/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=IL-DTIDB-DEVSQL;Database=DTIDatabase;Trusted_Connection=True;TrustServerCertificate=True"
   }
 }

--- a/DtiApplicationsIssuesTracker.Server/appsettings.json
+++ b/DtiApplicationsIssuesTracker.Server/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=IL-DTIDB-DEVSQL;Database=DTIDatabase;Trusted_Connection=True;TrustServerCertificate=True"
+  }
 }

--- a/dtiapplicationsissuestracker.client/src/App.tsx
+++ b/dtiapplicationsissuestracker.client/src/App.tsx
@@ -1,58 +1,191 @@
-import { useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import './App.css';
 
-interface Forecast {
-    date: string;
-    temperatureC: number;
-    temperatureF: number;
-    summary: string;
+interface Repository { id: number; name: string; }
+interface Category { id: number; name: string; }
+interface DataSource { id: number; name: string; }
+
+interface Issue {
+    id: number;
+    repositoryId: number;
+    categoryId: number;
+    dataSourceId?: number;
+    status: number;
+    description: string;
+    resolution?: string;
 }
 
+const statusOptions = [
+    { value: 0, label: 'Open' },
+    { value: 1, label: 'Resolved' }
+];
+
 function App() {
-    const [forecasts, setForecasts] = useState<Forecast[]>();
+    const [repositories, setRepositories] = useState<Repository[]>([]);
+    const [categories, setCategories] = useState<Category[]>([]);
+    const [dataSources, setDataSources] = useState<DataSource[]>([]);
+    const [issues, setIssues] = useState<Issue[]>([]);
+
+    const [repositoryId, setRepositoryId] = useState(0);
+    const [newRepo, setNewRepo] = useState('');
+    const [categoryId, setCategoryId] = useState(0);
+    const [newCategory, setNewCategory] = useState('');
+    const [dataSourceId, setDataSourceId] = useState<number | undefined>(undefined);
+    const [newDataSource, setNewDataSource] = useState('');
+    const [status, setStatus] = useState(0);
+    const [description, setDescription] = useState('');
+    const [resolution, setResolution] = useState('');
 
     useEffect(() => {
-        populateWeatherData();
+        loadAll();
     }, []);
 
-    const contents = forecasts === undefined
-        ? <p><em>Loading... Please refresh once the ASP.NET backend has started. See <a href="https://aka.ms/jspsintegrationreact">https://aka.ms/jspsintegrationreact</a> for more details.</em></p>
-        : <table className="table table-striped" aria-labelledby="tableLabel">
-            <thead>
-                <tr>
-                    <th>Date</th>
-                    <th>Temp. (C)</th>
-                    <th>Temp. (F)</th>
-                    <th>Summary</th>
-                </tr>
-            </thead>
-            <tbody>
-                {forecasts.map(forecast =>
-                    <tr key={forecast.date}>
-                        <td>{forecast.date}</td>
-                        <td>{forecast.temperatureC}</td>
-                        <td>{forecast.temperatureF}</td>
-                        <td>{forecast.summary}</td>
-                    </tr>
-                )}
-            </tbody>
-        </table>;
+    async function loadAll() {
+        const [repos, cats, dss, iss] = await Promise.all([
+            fetch('/api/issuetracker/repositories').then(r => r.json()),
+            fetch('/api/issuetracker/categories').then(r => r.json()),
+            fetch('/api/issuetracker/datasources').then(r => r.json()),
+            fetch('/api/issuetracker/issues').then(r => r.json()),
+        ]);
+        setRepositories(repos);
+        setCategories(cats);
+        setDataSources(dss);
+        setIssues(iss);
+    }
 
-    return (
-        <div>
-            <h1 id="tableLabel">Weather forecast</h1>
-            <p>This component demonstrates fetching data from the server.</p>
-            {contents}
-        </div>
-    );
+    async function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        let repoId = repositoryId;
+        if (!repoId && newRepo) {
+            const r = await fetch('/api/issuetracker/repositories', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: newRepo })
+            });
+            const repo = await r.json();
+            repoId = repo.id;
+            setRepositories([...repositories, repo]);
+            setNewRepo('');
+        }
+        let catId = categoryId;
+        if (!catId && newCategory) {
+            const r = await fetch('/api/issuetracker/categories', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: newCategory })
+            });
+            const cat = await r.json();
+            catId = cat.id;
+            setCategories([...categories, cat]);
+            setNewCategory('');
+        }
+        let dsId = dataSourceId;
+        if (categories.find(c => c.id === catId)?.name === 'Data') {
+            if (!dsId && newDataSource) {
+                const r = await fetch('/api/issuetracker/datasources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name: newDataSource })
+                });
+                const ds = await r.json();
+                dsId = ds.id;
+                setDataSources([...dataSources, ds]);
+                setNewDataSource('');
+            }
+        } else {
+            dsId = undefined;
+        }
 
-    async function populateWeatherData() {
-        const response = await fetch('weatherforecast');
-        if (response.ok) {
-            const data = await response.json();
-            setForecasts(data);
+        const issueBody = {
+            repositoryId: repoId,
+            categoryId: catId,
+            dataSourceId: dsId,
+            status,
+            description,
+            resolution: resolution || undefined
+        };
+
+        const res = await fetch('/api/issuetracker/issues', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(issueBody)
+        });
+        if (res.ok) {
+            const issue = await res.json();
+            setIssues([...issues, issue]);
+            setDescription('');
+            setResolution('');
+            setRepositoryId(0);
+            setCategoryId(0);
+            setDataSourceId(undefined);
         }
     }
+
+    const selectedCategory = categories.find(c => c.id === categoryId)?.name;
+    const showDataSource = selectedCategory === 'Data';
+
+    return (
+        <div className="container">
+            <h1>Issue Tracker</h1>
+            <form onSubmit={handleSubmit}>
+                <div>
+                    <label>Repository: </label>
+                    <select value={repositoryId} onChange={e => setRepositoryId(parseInt(e.target.value))}>
+                        <option value={0}>--Add New--</option>
+                        {repositories.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+                    </select>
+                    {repositoryId === 0 && (
+                        <input value={newRepo} onChange={e => setNewRepo(e.target.value)} placeholder="New repository" />
+                    )}
+                </div>
+                <div>
+                    <label>Category: </label>
+                    <select value={categoryId} onChange={e => setCategoryId(parseInt(e.target.value))}>
+                        <option value={0}>--Add New--</option>
+                        {categories.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                    </select>
+                    {categoryId === 0 && (
+                        <input value={newCategory} onChange={e => setNewCategory(e.target.value)} placeholder="New category" />
+                    )}
+                </div>
+                {showDataSource && (
+                    <div>
+                        <label>Data Source: </label>
+                        <select value={dataSourceId ?? 0} onChange={e => setDataSourceId(parseInt(e.target.value))}>
+                            <option value={0}>--Add New--</option>
+                            {dataSources.map(d => <option key={d.id} value={d.id}>{d.name}</option>)}
+                        </select>
+                        {(dataSourceId === undefined || dataSourceId === 0) && (
+                            <input value={newDataSource} onChange={e => setNewDataSource(e.target.value)} placeholder="New data source" />
+                        )}
+                    </div>
+                )}
+                <div>
+                    <label>Status: </label>
+                    <select value={status} onChange={e => setStatus(parseInt(e.target.value))}>
+                        {statusOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label>Description: </label>
+                    <textarea value={description} onChange={e => setDescription(e.target.value)} />
+                </div>
+                <div>
+                    <label>Resolution: </label>
+                    <textarea value={resolution} onChange={e => setResolution(e.target.value)} />
+                </div>
+                <button type="submit">Add Issue</button>
+            </form>
+            <h2>Existing Issues</h2>
+            <ul>
+                {issues.map(i => (
+                    <li key={i.id}>
+                        #{i.id} {repositories.find(r => r.id === i.repositoryId)?.name} - {categories.find(c => c.id === i.categoryId)?.name} - {statusOptions.find(s => s.value === i.status)?.label}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
 }
 
 export default App;


### PR DESCRIPTION
## Summary
- switch API persistence to use EF Core
- register IssueTrackingContext with SQL Server connection string
- map the Issue model to `ApplicationIssuesTracking` table
- seed database on startup and update controller to use the DbContext

## Testing
- `npm run build` *(fails: Cannot find module 'react')*
- `dotnet build DtiApplicationsIssuesTracker.Server/DtiApplicationsIssuesTracker.Server.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_6883aa0b336c832f860a16ebf3be7fd8